### PR TITLE
fix #41

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
             "role": "Developer"
         }
     ],
+    "autoload": {
+        "classmap": ["lib/"]
+    },
     "require": {
         "php": ">=5.2.0"
     }


### PR DESCRIPTION
give composer the ability to index the PSR-0 classes in a classmap

this is a fix for https://github.com/dready92/PHP-on-Couch/issues/41
